### PR TITLE
remove ocamlfind from compiler definitions

### DIFF
--- a/opam/compilers/3.12.1+mirage-unix-direct.comp
+++ b/opam/compilers/3.12.1+mirage-unix-direct.comp
@@ -2,7 +2,7 @@ opam-version: "1"
 name: "3.12.1"
 src: "http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz"
 make: [ "world" "world.opt" ]
-packages : [ "base-unix" "base-bigarray" "base-threads" "lwt" "ocamlfind" ]
+packages : [ "base-unix" "base-bigarray" "base-threads" "lwt" ]
 env: [
   [ MIRAGE_OS="unix" ]
   [ MIRAGE_NET="direct" ]

--- a/opam/compilers/3.12.1+mirage-xen.comp
+++ b/opam/compilers/3.12.1+mirage-xen.comp
@@ -12,4 +12,4 @@ env: [
    [MIRAGE_OS="xen"]
    [MIRAGE_NET="direct"]
 ]
-packages: [ "lwt" "ocamlfind" ]
+packages: [ "lwt" ]


### PR DESCRIPTION
per thomas' suggestion, to fix the odd 

```
...
  install /Users/mort/.opam/mir-unix/lib/ocaml/ocamlbuild/ocamlbuild.o

  install /Users/mort/.opam/mir-unix/man/man1/ocamlbuild.1

(W)Debcudf: Package (ocamlfind,1.3.1) does not have an associated cudf version

  'opam switch -alias mir-unix 3.12.1+mirage-unix-direct' failed

Fatal error: exception Not_found

Raised at file "src/opam.ml", line 362, characters 17-18
```

error
